### PR TITLE
fix login without API-key in account

### DIFF
--- a/lib/LoginExecutor.rb
+++ b/lib/LoginExecutor.rb
@@ -108,8 +108,9 @@ module LoginCommands
             @session.cookie_jar << cookie
             @loggedin = true
             begin
-                  text = Nokogiri::HTML(@session.get("https://steamcommunity.com/dev/apikey").content).css('#bodyContents_ex').css('p').first.text.split(' ')
+                  text = Nokogiri::HTML(@session.get("https://steamcommunity.com/dev/apikey").content).css('#bodyContents_ex').css('p').first.text
                   if text.include?('Registering for a Steam Web API Key will enable you to access many Steam features from your own website') == false
+                        text = text.split(' ')
                         @api_key = text[1]
                   end
             rescue

--- a/lib/LoginExecutor.rb
+++ b/lib/LoginExecutor.rb
@@ -110,8 +110,7 @@ module LoginCommands
             begin
                   text = Nokogiri::HTML(@session.get("https://steamcommunity.com/dev/apikey").content).css('#bodyContents_ex').css('p').first.text
                   if text.include?('Registering for a Steam Web API Key will enable you to access many Steam features from your own website') == false
-                        text = text.split(' ')
-                        @api_key = text[1]
+                        @api_key = text.split(' ')[1]
                   end
             rescue
                   output "Could not retrieve api_key"


### PR DESCRIPTION
fix login without API-key in account
If the account does not have an api key, we received an error.

Error 
Traceback (most recent call last):
	6: from bot.rb:3:in `<main>'
	5: from bot.rb:3:in `new'
	4: from /home/berdnikov/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/steam-trade-0.3.2/lib/steam-trade.rb:110:in `initialize'
	3: from /home/berdnikov/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/steam-trade-0.3.2/lib/LoginExecutor.rb:126:in `login'
	2: from /home/berdnikov/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/steam-trade-0.3.2/lib/Playerinfo.rb:13:in `get_player_summaries'
	1: from /home/berdnikov/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/mechanize-2.7.6/lib/mechanize.rb:464:in `get'
/home/berdnikov/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/mechanize-2.7.6/lib/mechanize/http/agent.rb:329:in `fetch': 403 => Net::HTTPForbidden for http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=for&steamids=76561199004300594 -- unhandled response (Mechanize::ResponseCodeError)
